### PR TITLE
Deprecating API that contains get prefix

### DIFF
--- a/docs/devel/classes/datatype.rst
+++ b/docs/devel/classes/datatype.rst
@@ -3,4 +3,4 @@ Datatype
 
 .. doxygenfunction:: mpicpp_lite::create_mpi_datatype
 
-.. doxygenfunction:: mpicpp_lite::get_mpi_datatype
+.. doxygenfunction:: mpicpp_lite::mpi_datatype

--- a/include/mpicpp-lite/impl/Communicator.h
+++ b/include/mpicpp-lite/impl/Communicator.h
@@ -688,8 +688,7 @@ template <typename T>
 inline void
 Communicator::send(int dest, int tag, const T * values, int n) const
 {
-    MPI_CHECK_SELF(
-        MPI_Send(const_cast<T *>(values), n, get_mpi_datatype<T>(), dest, tag, this->comm));
+    MPI_CHECK_SELF(MPI_Send(const_cast<T *>(values), n, mpi_datatype<T>(), dest, tag, this->comm));
 }
 
 template <typename T, typename A>
@@ -729,13 +728,8 @@ inline Status
 Communicator::recv(int source, int tag, T * values, int n) const
 {
     MPI_Status status = { 0 };
-    MPI_CHECK_SELF(MPI_Recv(const_cast<T *>(values),
-                            n,
-                            get_mpi_datatype<T>(),
-                            source,
-                            tag,
-                            this->comm,
-                            &status));
+    MPI_CHECK_SELF(
+        MPI_Recv(const_cast<T *>(values), n, mpi_datatype<T>(), source, tag, this->comm, &status));
     return { status };
 }
 
@@ -746,7 +740,7 @@ Communicator::recv(int source, int tag, std::vector<T, A> & values) const
     MPI_Status status = { 0 };
     MPI_CHECK_SELF(MPI_Probe(source, tag, this->comm, &status));
     int size = 0;
-    MPI_Get_count(&status, get_mpi_datatype<T>(), &size);
+    MPI_Get_count(&status, mpi_datatype<T>(), &size);
     values.resize(size);
     return recv(source, tag, values.data(), size);
 }
@@ -791,13 +785,8 @@ Communicator::isend(int dest, int tag, const T * values, int n) const
 {
     assert(values != nullptr);
     MPI_Request request;
-    MPI_CHECK_SELF(MPI_Isend(const_cast<T *>(values),
-                             n,
-                             get_mpi_datatype<T>(),
-                             dest,
-                             tag,
-                             this->comm,
-                             &request));
+    MPI_CHECK_SELF(
+        MPI_Isend(const_cast<T *>(values), n, mpi_datatype<T>(), dest, tag, this->comm, &request));
     return { request };
 }
 
@@ -818,7 +807,7 @@ Communicator::irecv(int source, int tag, T * values, int n) const
     MPI_Request request;
     MPI_CHECK_SELF(MPI_Irecv(const_cast<T *>(values),
                              n,
-                             get_mpi_datatype<T>(),
+                             mpi_datatype<T>(),
                              source,
                              tag,
                              this->comm,
@@ -881,7 +870,7 @@ template <typename T>
 inline void
 Communicator::broadcast(T * values, int n, int root) const
 {
-    MPI_CHECK_SELF(MPI_Bcast(values, n, get_mpi_datatype<T>(), root, this->comm));
+    MPI_CHECK_SELF(MPI_Bcast(values, n, mpi_datatype<T>(), root, this->comm));
 }
 
 template <typename KEY, typename VALUE>
@@ -956,7 +945,7 @@ template <typename T>
 inline void
 Communicator::gather(const T * in_values, int n, T * out_values, int root) const
 {
-    auto type = get_mpi_datatype<T>();
+    auto type = mpi_datatype<T>();
     MPI_CHECK_SELF(
         MPI_Gather(const_cast<T *>(in_values), n, type, out_values, n, type, root, this->comm));
 }
@@ -986,11 +975,11 @@ Communicator::gather(const std::vector<T> & in_values,
     out_values.resize(n_out_vals);
     MPI_CHECK_SELF(MPI_Gatherv(in_values.data(),
                                in_values.size(),
-                               get_mpi_datatype<T>(),
+                               mpi_datatype<T>(),
                                out_values.data(),
                                out_counts.data(),
                                out_offsets.data(),
-                               get_mpi_datatype<T>(),
+                               mpi_datatype<T>(),
                                root,
                                this->comm));
 }
@@ -1001,10 +990,10 @@ Communicator::all_gather(const T * in_value, int n, T * out_values, int m) const
 {
     MPI_CHECK_SELF(MPI_Allgather(in_value,
                                  n,
-                                 get_mpi_datatype<T>(),
+                                 mpi_datatype<T>(),
                                  out_values,
                                  m,
-                                 get_mpi_datatype<T>(),
+                                 mpi_datatype<T>(),
                                  this->comm));
 }
 
@@ -1049,11 +1038,11 @@ Communicator::all_gather(const std::vector<T> & in_values,
     out_values.resize(n_out_vals);
     MPI_CHECK_SELF(MPI_Allgatherv(in_values.data(),
                                   in_values.size(),
-                                  get_mpi_datatype<T>(),
+                                  mpi_datatype<T>(),
                                   out_values.data(),
                                   out_counts.data(),
                                   out_offsets.data(),
-                                  get_mpi_datatype<T>(),
+                                  mpi_datatype<T>(),
                                   this->comm));
 }
 
@@ -1077,7 +1066,7 @@ template <typename T>
 inline void
 Communicator::scatter(const T * in_values, T * out_values, int n, int root) const
 {
-    auto type = get_mpi_datatype<T>();
+    auto type = mpi_datatype<T>();
     MPI_CHECK_SELF(
         MPI_Scatter(const_cast<T *>(in_values), n, type, out_values, n, type, root, this->comm));
 }
@@ -1099,7 +1088,7 @@ Communicator::reduce(const T * in_values, int n, T * out_values, Op, int root) c
     MPI_CHECK_SELF(MPI_Reduce(const_cast<T *>(in_values),
                               out_values,
                               n,
-                              get_mpi_datatype<T>(),
+                              mpi_datatype<T>(),
                               mpi_op,
                               root,
                               this->comm));
@@ -1134,7 +1123,7 @@ Communicator::all_reduce(const T * in_values, int n, T * out_values, Op) const
     MPI_CHECK_SELF(MPI_Allreduce(const_cast<T *>(in_values),
                                  out_values,
                                  n,
-                                 get_mpi_datatype<T>(),
+                                 mpi_datatype<T>(),
                                  mpi_op,
                                  this->comm));
 }
@@ -1169,10 +1158,10 @@ Communicator::all_to_all(const T * in_values, int n, T * out_values, int m) cons
 {
     MPI_CHECK_SELF(MPI_Alltoall(in_values,
                                 n,
-                                get_mpi_datatype<T>(),
+                                mpi_datatype<T>(),
                                 out_values,
                                 m,
-                                get_mpi_datatype<T>(),
+                                mpi_datatype<T>(),
                                 this->comm));
 }
 
@@ -1238,11 +1227,11 @@ Communicator::all_to_all(const std::vector<T> & in_values,
     MPI_CHECK_SELF(MPI_Alltoallv(in_values.data(),
                                  in_counts.data(),
                                  in_offsets.data(),
-                                 get_mpi_datatype<T>(),
+                                 mpi_datatype<T>(),
                                  out_values.data(),
                                  out_counts.data(),
                                  out_offsets.data(),
-                                 get_mpi_datatype<T>(),
+                                 mpi_datatype<T>(),
                                  this->comm));
 }
 
@@ -1261,12 +1250,8 @@ inline void
 Communicator::scan(const T * in_values, int n, T * out_values, Op) const
 {
     auto mpi_op = op::provider<T, Op, op::Operation<Op, T>::is_native::value>::op();
-    MPI_CHECK_SELF(MPI_Scan(const_cast<T *>(in_values),
-                            out_values,
-                            n,
-                            get_mpi_datatype<T>(),
-                            mpi_op,
-                            this->comm));
+    MPI_CHECK_SELF(
+        MPI_Scan(const_cast<T *>(in_values), out_values, n, mpi_datatype<T>(), mpi_op, this->comm));
 }
 
 template <typename T, typename Op>
@@ -1294,7 +1279,7 @@ Communicator::exscan(const T * in_values, int n, T * out_values, Op) const
     MPI_CHECK_SELF(MPI_Exscan(const_cast<T *>(in_values),
                               out_values,
                               n,
-                              get_mpi_datatype<T>(),
+                              mpi_datatype<T>(),
                               mpi_op,
                               this->comm));
 }

--- a/include/mpicpp-lite/impl/Datatype.h
+++ b/include/mpicpp-lite/impl/Datatype.h
@@ -25,105 +25,105 @@ create_mpi_datatype()
 /// @return `MPI_Datatype` that is used in the MPI API
 template <typename T>
 inline MPI_Datatype
-get_mpi_datatype()
+mpi_datatype()
 {
     return MPI_DATATYPE_NULL;
 }
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<char>()
+mpi_datatype<char>()
 {
     return MPI_BYTE;
 }
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<short>()
+mpi_datatype<short>()
 {
     return MPI_SHORT;
 }
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<int>()
+mpi_datatype<int>()
 {
     return MPI_INT;
 }
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<long int>()
+mpi_datatype<long int>()
 {
     return MPI_LONG;
 }
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<long long int>()
+mpi_datatype<long long int>()
 {
     return MPI_LONG_LONG;
 }
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<unsigned char>()
+mpi_datatype<unsigned char>()
 {
     return MPI_UNSIGNED_CHAR;
 }
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<unsigned short>()
+mpi_datatype<unsigned short>()
 {
     return MPI_UNSIGNED_SHORT;
 }
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<unsigned int>()
+mpi_datatype<unsigned int>()
 {
     return MPI_UNSIGNED;
 }
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<unsigned long int>()
+mpi_datatype<unsigned long int>()
 {
     return MPI_UNSIGNED_LONG;
 }
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<unsigned long long int>()
+mpi_datatype<unsigned long long int>()
 {
     return MPI_UNSIGNED_LONG_LONG;
 }
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<float>()
+mpi_datatype<float>()
 {
     return MPI_FLOAT;
 }
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<double>()
+mpi_datatype<double>()
 {
     return MPI_DOUBLE;
 }
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<long double>()
+mpi_datatype<long double>()
 {
     return MPI_LONG_DOUBLE;
 }
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<bool>()
+mpi_datatype<bool>()
 {
     return MPI_CXX_BOOL;
 }
@@ -132,12 +132,19 @@ get_mpi_datatype<bool>()
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<std::byte>()
+mpi_datatype<std::byte>()
 {
     return MPI_BYTE;
 }
 
 #endif
+
+template <typename T>
+[[deprecated("use `mpi_datatype` instead")]] inline MPI_Datatype
+get_mpi_datatype()
+{
+    return mpi_datatype<T>();
+}
 
 /// Register a new datatype for MPI communication
 ///
@@ -192,7 +199,7 @@ template <typename T>
 inline int
 type_size()
 {
-    auto dt = get_mpi_datatype<T>();
+    auto dt = mpi_datatype<T>();
     int size;
     MPI_CHECK(MPI_Type_size(dt, &size));
     return size;

--- a/include/mpicpp-lite/impl/Environment.h
+++ b/include/mpicpp-lite/impl/Environment.h
@@ -78,11 +78,17 @@ Environment::is_finalized()
 ///
 /// @return Tuple with the version and subversion of MPI
 inline std::tuple<int, int>
-get_mpi_version()
+version()
 {
     int version, subversion;
     MPI_CHECK(MPI_Get_version(&version, &subversion));
     return std::make_tuple(version, subversion);
+}
+
+[[deprecated("use `version` instead")]] inline std::tuple<int, int>
+get_mpi_version()
+{
+    return version();
 }
 
 /// Creates a division of processors in a cartesian grid

--- a/include/mpicpp-lite/impl/Environment.h
+++ b/include/mpicpp-lite/impl/Environment.h
@@ -6,7 +6,6 @@
 #include "mpi.h"
 #include "Error.h"
 #include <vector>
-#include <iostream>
 
 namespace mpicpp_lite {
 

--- a/include/mpicpp-lite/impl/Operation.h
+++ b/include/mpicpp-lite/impl/Operation.h
@@ -5,7 +5,6 @@
 
 #include "mpi.h"
 #include "Error.h"
-#include "Environment.h"
 #include <type_traits>
 
 namespace mpicpp_lite {

--- a/include/mpicpp-lite/impl/Status.h
+++ b/include/mpicpp-lite/impl/Status.h
@@ -74,7 +74,7 @@ inline int
 Status::get_count() const
 {
     int n;
-    MPI_Get_count(&this->status, get_mpi_datatype<T>(), &n);
+    MPI_Get_count(&this->status, mpi_datatype<T>(), &n);
     return n;
 }
 

--- a/include/mpicpp-lite/impl/Status.h
+++ b/include/mpicpp-lite/impl/Status.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "mpi.h"
+#include "Datatype.h"
 
 namespace mpicpp_lite {
 
@@ -33,12 +34,19 @@ public:
     /// @return Error code
     int error() const;
 
+    template <typename T>
+    [[deprecated("use `count` instead")]] int
+    get_count() const
+    {
+        return count<T>();
+    }
+
     /// Gets the number of "top level" elements
     ///
     /// @tparam T datatype of each receive buffer element
     /// @return The number of "top level" elements
     template <typename T>
-    int get_count() const;
+    int count() const;
 
     /// Type cast operators so we can pass this class directly into the MPI API
     operator MPI_Status *() { return &this->status; }
@@ -71,7 +79,7 @@ Status::error() const
 
 template <typename T>
 inline int
-Status::get_count() const
+Status::count() const
 {
     int n;
     MPI_Get_count(&this->status, mpi_datatype<T>(), &n);

--- a/tests/Datatype_test.cpp
+++ b/tests/Datatype_test.cpp
@@ -6,19 +6,19 @@ namespace mpi = mpicpp_lite;
 
 TEST(MPITest, std_datatypes)
 {
-    EXPECT_EQ(mpi::get_mpi_datatype<char>(), MPI_BYTE);
-    EXPECT_EQ(mpi::get_mpi_datatype<short>(), MPI_SHORT);
-    EXPECT_EQ(mpi::get_mpi_datatype<int>(), MPI_INT);
-    EXPECT_EQ(mpi::get_mpi_datatype<long int>(), MPI_LONG);
-    EXPECT_EQ(mpi::get_mpi_datatype<long long int>(), MPI_LONG_LONG);
-    EXPECT_EQ(mpi::get_mpi_datatype<unsigned char>(), MPI_UNSIGNED_CHAR);
-    EXPECT_EQ(mpi::get_mpi_datatype<unsigned short>(), MPI_UNSIGNED_SHORT);
-    EXPECT_EQ(mpi::get_mpi_datatype<unsigned int>(), MPI_UNSIGNED);
-    EXPECT_EQ(mpi::get_mpi_datatype<unsigned long int>(), MPI_UNSIGNED_LONG);
-    EXPECT_EQ(mpi::get_mpi_datatype<unsigned long long int>(), MPI_UNSIGNED_LONG_LONG);
-    EXPECT_EQ(mpi::get_mpi_datatype<float>(), MPI_FLOAT);
-    EXPECT_EQ(mpi::get_mpi_datatype<double>(), MPI_DOUBLE);
-    EXPECT_EQ(mpi::get_mpi_datatype<long double>(), MPI_LONG_DOUBLE);
+    EXPECT_EQ(mpi::mpi_datatype<char>(), MPI_BYTE);
+    EXPECT_EQ(mpi::mpi_datatype<short>(), MPI_SHORT);
+    EXPECT_EQ(mpi::mpi_datatype<int>(), MPI_INT);
+    EXPECT_EQ(mpi::mpi_datatype<long int>(), MPI_LONG);
+    EXPECT_EQ(mpi::mpi_datatype<long long int>(), MPI_LONG_LONG);
+    EXPECT_EQ(mpi::mpi_datatype<unsigned char>(), MPI_UNSIGNED_CHAR);
+    EXPECT_EQ(mpi::mpi_datatype<unsigned short>(), MPI_UNSIGNED_SHORT);
+    EXPECT_EQ(mpi::mpi_datatype<unsigned int>(), MPI_UNSIGNED);
+    EXPECT_EQ(mpi::mpi_datatype<unsigned long int>(), MPI_UNSIGNED_LONG);
+    EXPECT_EQ(mpi::mpi_datatype<unsigned long long int>(), MPI_UNSIGNED_LONG_LONG);
+    EXPECT_EQ(mpi::mpi_datatype<float>(), MPI_FLOAT);
+    EXPECT_EQ(mpi::mpi_datatype<double>(), MPI_DOUBLE);
+    EXPECT_EQ(mpi::mpi_datatype<long double>(), MPI_LONG_DOUBLE);
 }
 
 namespace {
@@ -54,7 +54,7 @@ create_mpi_datatype<CustomData>()
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<CustomData>()
+mpi_datatype<CustomData>()
 {
     static auto dt = mpi::register_mpi_datatype<CustomData>();
     return dt;
@@ -80,12 +80,12 @@ template <>
 inline MPI_Datatype
 create_mpi_datatype<CustomEnum>()
 {
-    return type_contiguous(1, get_mpi_datatype<unsigned char>());
+    return type_contiguous(1, mpi_datatype<unsigned char>());
 }
 
 template <>
 inline MPI_Datatype
-get_mpi_datatype<CustomEnum>()
+mpi_datatype<CustomEnum>()
 {
     static auto dt = mpi::register_mpi_datatype<CustomEnum>();
     return dt;

--- a/tests/MPI_test.cpp
+++ b/tests/MPI_test.cpp
@@ -6,7 +6,7 @@ using namespace testing;
 
 TEST(MPITest, get_version)
 {
-    auto [major, minor] = mpicpp_lite::get_mpi_version();
+    auto [major, minor] = mpicpp_lite::version();
     EXPECT_GE(major, 1);
     EXPECT_GE(minor, 0);
 }


### PR DESCRIPTION
- Small cleanup in #includes
- Deprecating `get_mpi_datatype`, using `mpi_datatype` instead
- Deprecating `Status::get_count`, using `count` instead
- Deprecating `get_mpi_version`, use `version` instead
