### PR TITLE
Adding `Communicator::free`

### DIFF
--- a/include/mpicpp-lite/impl/Communicator.h
+++ b/include/mpicpp-lite/impl/Communicator.h
@@ -30,6 +30,9 @@ public:
     /// Copy constructor
     Communicator(const Communicator & comm);
 
+    /// Marks the communicator object for deallocation
+    void free();
+
     /// Determine the rank of the executing process in a communicator
     ///
     /// @return Rank of the executing process
@@ -626,6 +629,13 @@ inline Communicator::Communicator() : comm(MPI_COMM_WORLD) {}
 inline Communicator::Communicator(const MPI_Comm & comm) : comm(comm) {}
 
 inline Communicator::Communicator(const Communicator & comm) : comm(comm.comm) {}
+
+inline void
+Communicator::free()
+{
+    MPI_CHECK_SELF(MPI_Comm_free(&this->comm));
+    this->comm = MPI_COMM_NULL;
+}
 
 inline int
 Communicator::rank() const

--- a/tests/Group_test.cpp
+++ b/tests/Group_test.cpp
@@ -33,10 +33,13 @@ TEST(GroupTest, include)
             EXPECT_EQ(sub_comm.rank(), 1);
         else if (rank == 3)
             EXPECT_EQ(sub_comm.rank(), 2);
+        sub_comm.free();
     }
 
     sub_group.free();
     world_group.free();
+
+    EXPECT_FALSE(sub_comm.is_valid());
 }
 
 TEST(GroupTest, exclude)


### PR DESCRIPTION
When apps use custom comms, they need to be able to free them after they are done
using them.  Very useful for clean valgrind runs.
